### PR TITLE
Override iOS styling for input

### DIFF
--- a/src/app/public/styles/_forms.scss
+++ b/src/app/public/styles/_forms.scss
@@ -1,12 +1,5 @@
 @import "mixins";
 
-input[type=text].sky-form-control {
-  /* Remove device-specific styles */
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}
-
 .sky-form-control {
   width: 100%;
   padding: 6px 12px;
@@ -14,6 +7,13 @@ input[type=text].sky-form-control {
   line-height: $sky-line-height-base;
   font-size: $sky-font-size-base;
   color: $sky-text-color-default;
+
+  /* Remove device-specific styles */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
+  -webkit-border-radius: 0;
 
   &:focus {
     @include sky-field-status(active);

--- a/src/app/public/styles/_forms.scss
+++ b/src/app/public/styles/_forms.scss
@@ -1,5 +1,12 @@
 @import "mixins";
 
+input[type=text].sky-form-control {
+  /* Remove device-specific styles */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
 .sky-form-control {
   width: 100%;
   padding: 6px 12px;


### PR DESCRIPTION
Fixes https://github.com/blackbaud/skyux2/issues/1534

Overrides iOS default styling on input elements. See more about the appearance property here: https://css-tricks.com/almanac/properties/a/appearance/