### PR TITLE
Skipping visual tests if platform is VSTS

### DIFF
--- a/e2e/borders.e2e-spec.ts
+++ b/e2e/borders.e2e-spec.ts
@@ -3,6 +3,10 @@ import {
   SkyHostBrowser
 } from '@skyux-sdk/e2e';
 
+import {
+  ThemePlatformHelper
+} from './utils/theme-platform-utils';
+
 describe('Borders', () => {
 
   beforeEach(() => {
@@ -11,6 +15,10 @@ describe('Borders', () => {
   });
 
   it('should match the previous screenshot', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     expect('#sky-borders-demo')
       .toMatchBaselineScreenshot(done, {
         screenshotName: 'borders'

--- a/e2e/buttons.e2e-spec.ts
+++ b/e2e/buttons.e2e-spec.ts
@@ -9,6 +9,10 @@ import {
   SkyHostBrowser
 } from '@skyux-sdk/e2e';
 
+import {
+  ThemePlatformHelper
+} from './utils/theme-platform-utils';
+
 describe('Buttons', () => {
   function hoverMouseOverSelector(selector: string): any {
     return browser.actions()
@@ -22,6 +26,10 @@ describe('Buttons', () => {
   });
 
   it('should match default state screenshot', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     expect('#screenshot-buttons-default-state')
       .toMatchBaselineScreenshot(done, {
         screenshotName: 'default-state'
@@ -29,6 +37,10 @@ describe('Buttons', () => {
   });
 
   it('should match disabled state screenshot', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     expect('#screenshot-buttons-disabled-state')
       .toMatchBaselineScreenshot(done, {
         screenshotName: 'disabled-state'
@@ -36,6 +48,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering a primary button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('.sky-btn-primary').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'btn-primary-hover'
@@ -44,6 +60,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering a danger button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('.sky-btn-danger').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'btn-danger-hover'
@@ -52,6 +72,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering a default button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('.sky-btn-default').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'btn-default-hover'
@@ -60,6 +84,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering a link button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('.sky-btn-link').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'btn-link-hover'
@@ -68,6 +96,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering an inline link button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('.sky-btn-link-inline').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'btn-link-inline-hover'
@@ -76,6 +108,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering a borderless button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('.sky-btn-borderless').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'btn-link-borderless-hover'
@@ -84,6 +120,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering a borderless inline button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('.sky-btn-borderless-inline').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'btn-link-borderless-inline-hover'
@@ -92,6 +132,10 @@ describe('Buttons', () => {
   });
 
   it('should match the baseline screenshot while hovering an anchor button', function (done) {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     hoverMouseOverSelector('a.sky-btn').then(() => {
       expect('#screenshot-buttons-default-state').toMatchBaselineScreenshot(done, {
         screenshotName: 'anchor-btn-hover'

--- a/e2e/responsive.e2e-spec.ts
+++ b/e2e/responsive.e2e-spec.ts
@@ -8,6 +8,10 @@ import {
   SkyHostBrowser
 } from '@skyux-sdk/e2e';
 
+import {
+  ThemePlatformHelper
+} from './utils/theme-platform-utils';
+
 describe('Responsive mixins', () => {
 
   beforeEach(() => {
@@ -16,6 +20,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at lg screen size and xs container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.scrollTo('#xs-toggle');
     element(by.css('#xs-toggle')).click();
     SkyHostBrowser.scrollTo('#screenshot-responsive');
@@ -26,6 +34,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at lg screen size and sm container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.scrollTo('#sm-toggle');
     element(by.css('#sm-toggle')).click();
     SkyHostBrowser.scrollTo('#screenshot-responsive');
@@ -36,6 +48,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at lg screen size and md container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.scrollTo('#md-toggle');
     element(by.css('#md-toggle')).click();
     SkyHostBrowser.scrollTo('#screenshot-responsive');
@@ -46,6 +62,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at lg screen size and lg container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.scrollTo('#lg-toggle');
     element(by.css('#lg-toggle')).click();
     SkyHostBrowser.scrollTo('#screenshot-responsive');
@@ -56,6 +76,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at xs screen size and xs container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.setWindowBreakpoint('xs');
     SkyHostBrowser.scrollTo('#xs-toggle');
     element(by.css('#xs-toggle')).click();
@@ -67,6 +91,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at xs screen size and sm container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.setWindowBreakpoint('xs');
     SkyHostBrowser.scrollTo('#sm-toggle');
     element(by.css('#sm-toggle')).click();
@@ -78,6 +106,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at xs screen size and md container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.setWindowBreakpoint('xs');
     SkyHostBrowser.scrollTo('#md-toggle');
     element(by.css('#md-toggle')).click();
@@ -89,6 +121,10 @@ describe('Responsive mixins', () => {
   });
 
   it('should match screenshot at xs screen size and lg container', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     SkyHostBrowser.setWindowBreakpoint('xs');
     SkyHostBrowser.scrollTo('#lg-toggle');
     element(by.css('#lg-toggle')).click();

--- a/e2e/utils/theme-platform-utils.ts
+++ b/e2e/utils/theme-platform-utils.ts
@@ -1,0 +1,12 @@
+export class ThemePlatformHelper {
+  public static shouldSkipVisualTests() {
+    const idxPlatformKey = process.argv.indexOf('--platform');
+    const idxPlatformVSTS = process.argv.indexOf('vsts');
+
+    // Minimist sure is nice
+    if (idxPlatformKey > -1 && idxPlatformVSTS > -1 && idxPlatformVSTS === (idxPlatformKey + 1)) {
+      console.warn('Platform is VSTS - skipping visual test.');
+      return true;
+    }
+  }
+}

--- a/e2e/validation.e2e-spec.ts
+++ b/e2e/validation.e2e-spec.ts
@@ -8,6 +8,10 @@ import {
   SkyHostBrowser
 } from '@skyux-sdk/e2e';
 
+import {
+  ThemePlatformHelper
+} from './utils/theme-platform-utils';
+
 describe('Validation', () => {
 
   beforeEach(() => {
@@ -16,6 +20,10 @@ describe('Validation', () => {
   });
 
   it('should match the text input required screenshot', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     // Click on input
     element(by.css('#text-input input')).click();
     // Click off input
@@ -27,6 +35,10 @@ describe('Validation', () => {
   });
 
   it('should match the select input required screenshot', (done) => {
+    if (ThemePlatformHelper.shouldSkipVisualTests()) {
+      return done();
+    }
+
     // Click on select
     element(by.css('#select-input select')).click();
     // Click off select


### PR DESCRIPTION
I created this PR to show how we could skip visual tests for certain platforms.

This would be an alternative to allowing the command to be overridden in the ES pipeline.

I felt this a better approach given it's less moving pieces and no one else has needed that functionality from the pipeline.

I'm happy to discuss more though.