### PR TITLE
Release 4.15.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.15.5 (2021-04-09)
+
+- Fixed the `skyThemeIf` and `skyThemeClass` directives to work properly when `SkyThemeService` is provided but not initialized. [#220](https://github.com/blackbaud/skyux-theme/pull/220)
+
 # 4.15.4 (2021-03-24)
 
 - Fixed the `skyThemeIf` and `skyThemeClass` directives to work properly when `SkyThemeService` is not provided. [#217](https://github.com/blackbaud/skyux-theme/pull/217)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/theme",
-  "version": "4.15.4",
+  "version": "4.15.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/theme",
-  "version": "4.15.4",
+  "version": "4.15.5",
   "description": "SKY UX Theme",
   "scripts": {
     "test": "npm run build:dev-bundle && skyux test --coverage library --logFormat none",


### PR DESCRIPTION
- Fixed the `skyThemeIf` and `skyThemeClass` directives to work properly when `SkyThemeService` is provided but not initialized. [#220](https://github.com/blackbaud/skyux-theme/pull/220)
