### PR TITLE
Release 4.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.16.3 (2021-05-19)
+
+- Added a CSS class for omitting link style on an `<a>` that does not have an `href` attribute. [#229](https://github.com/blackbaud/skyux-theme/pull/229)
+
 # 4.16.2 (2021-04-30)
 
 - Fixed placeholder text styles in modern theme. [#226](https://github.com/blackbaud/skyux-theme/pull/226)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.16.3 (2021-05-19)
 
-- Added a CSS class for omitting link style on an `<a>` that does not have an `href` attribute. [#229](https://github.com/blackbaud/skyux-theme/pull/229)
+- Added a CSS class to omit the link style on `<a>` tags that do not have `href` attributes. [#229](https://github.com/blackbaud/skyux-theme/pull/229)
 
 # 4.16.2 (2021-04-30)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/theme",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1532,9 +1532,9 @@
       }
     },
     "@skyux-sdk/e2e": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@skyux-sdk/e2e/-/e2e-4.0.1.tgz",
-      "integrity": "sha512-f0gJazMMfNGIVYn63RWvh/NAyC0ptWPCAgydKOjFYF42nASQ4DvY20ZQjPpfRZpwSbNdFwQXlV8KXqU22x4OQA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@skyux-sdk/e2e/-/e2e-4.0.2.tgz",
+      "integrity": "sha512-Nso8EIGLO8r7edDNqD4oKtfacfv1wqj9GWAZddmTeaa3nFzxz0cQMabjuVXQI6DGguvFsHWdPirDGtDMg0+oWA==",
       "dev": true,
       "requires": {
         "@blackbaud/skyux-logger": "1.1.2",
@@ -1730,9 +1730,9 @@
       }
     },
     "@skyux/lookup": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@skyux/lookup/-/lookup-4.12.1.tgz",
-      "integrity": "sha512-vcYh8Nf9Yf7DnaU1pdOzfiEyHPFSWejctXiMV9Ko+68Kq6kEqJsUxSSapfF+8u24f+3qXDk3QWOQgnF4CmZFBA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@skyux/lookup/-/lookup-4.13.1.tgz",
+      "integrity": "sha512-6PYffcv7A8ksxFWHyaqdFzngVYqmrd+lfS+P4rIsQgPAqIhBN5EeLtLvitBVy0OiI0zbepu6wm7qEpD/kkLQXQ==",
       "dev": true,
       "requires": {
         "intl-tel-input": "14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/theme",
-  "version": "4.16.2",
+  "version": "4.16.3",
   "description": "SKY UX Theme",
   "scripts": {
     "test": "npm run build:dev-bundle && skyux test --coverage library --logFormat none",
@@ -39,7 +39,7 @@
     "@blackbaud/skyux-lib-stache": "4.2.2",
     "@skyux-sdk/builder": "4.8.2",
     "@skyux-sdk/builder-plugin-skyux": "4.1.4",
-    "@skyux-sdk/e2e": "4.0.1",
+    "@skyux-sdk/e2e": "4.0.2",
     "@skyux-sdk/testing": "4.2.3",
     "@skyux/animations": "4.0.1",
     "@skyux/assets": "4.0.1",
@@ -55,7 +55,7 @@
     "@skyux/layout": "4.6.2",
     "@skyux/list-builder-common": "4.0.1",
     "@skyux/lists": "4.7.2",
-    "@skyux/lookup": "4.12.1",
+    "@skyux/lookup": "4.13.1",
     "@skyux/modals": "4.5.3",
     "@skyux/omnibar-interop": "4.0.1",
     "@skyux/popovers": "4.5.2",


### PR DESCRIPTION
- Added a CSS class for omitting link style on an `<a>` that does not have an `href` attribute. [#229](https://github.com/blackbaud/skyux-theme/pull/229)