### PR TITLE
Remove space from unstyled list

### DIFF
--- a/e2e/theming.e2e-spec.ts
+++ b/e2e/theming.e2e-spec.ts
@@ -75,6 +75,11 @@ describe('Theming', () => {
       selectSection('text');
       validate(done);
     });
+
+    it('unstyled list should match the previous screenshot', (done) => {
+      selectSection('unstyled-list');
+      validate(done);
+    });
   });
 
   describe('when modern theme', () => {
@@ -107,6 +112,11 @@ describe('Theming', () => {
         selectSection('text');
         validate(done);
       });
+
+      it('unstyled list should match the previous screenshot', (done) => {
+        selectSection('unstyled-list');
+        validate(done);
+      });
     });
 
     describe('in dark mode', () => {
@@ -136,6 +146,11 @@ describe('Theming', () => {
 
       it('text should match the previous screenshot', (done) => {
         selectSection('text');
+        validate(done);
+      });
+
+      it('unstyled list should match the previous screenshot', (done) => {
+        selectSection('unstyled-list');
         validate(done);
       });
     });

--- a/src/app/public/styles/_theme.scss
+++ b/src/app/public/styles/_theme.scss
@@ -88,11 +88,7 @@ a {
 
 .sky-list-unstyled {
   list-style: none;
-  padding: 0;
-
-  li {
-    padding-bottom: $sky-padding-half;
-  }
+  padding-left: 0;
 }
 
 mark.sky-highlight-mark {

--- a/src/app/public/styles/_theme.scss
+++ b/src/app/public/styles/_theme.scss
@@ -89,6 +89,7 @@ a {
 .sky-list-unstyled {
   list-style: none;
   padding-left: 0;
+  margin: 0;
 }
 
 mark.sky-highlight-mark {

--- a/src/app/public/styles/_theme.scss
+++ b/src/app/public/styles/_theme.scss
@@ -89,7 +89,12 @@ a {
 .sky-list-unstyled {
   list-style: none;
   padding-left: 0;
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+
+  li:not(:last-of-type) {
+    padding-bottom: $sky-padding-half;
+  }
 }
 
 mark.sky-highlight-mark {

--- a/src/app/visual/theming/theming-demo.component.html
+++ b/src/app/visual/theming/theming-demo.component.html
@@ -11,6 +11,7 @@
     <option value="margin">Margin</option>
     <option value="padding">Padding</option>
     <option value="text">Text</option>
+    <option value="unstyled-list">Unstyled list</option>
   </select>
 </div>
 
@@ -100,5 +101,15 @@
     <div id="placeholder-test">
       <input type="text" name="fname" class="sky-form-control" placeholder="Enter a name.">
     </div>
+  </ng-container>
+
+  <ng-container *ngIf="section === 'unstyled-list'">
+    <div class="sky-font-body-default">Text above</div>
+    <ul class="sky-list-unstyled">
+      <li>Unstyled list item 1</li>
+      <li>Unstyled list item 2</li>
+      <li>Unstyled list item 3</li>
+    </ul>
+    <div class="sky-font-body-default">Text below</div>
   </ng-container>
 </div>


### PR DESCRIPTION
Fix for [Radio and Checkbox have weird spacing between Label and Control Group](https://github.com/blackbaud/skyux-forms/issues/150).